### PR TITLE
Simplify pagination cursor extraction

### DIFF
--- a/examples/businessrepo/repo.go
+++ b/examples/businessrepo/repo.go
@@ -1,0 +1,69 @@
+package businessrepo
+
+import (
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+	"gorm.io/gorm"
+)
+
+var errNilDB = errors.New("businessrepo: nil db")
+
+type BusinessRepo struct {
+	db *gorm.DB
+}
+
+type BusinessMember struct {
+	ID         string    `gorm:"column:id;primaryKey"`
+	BusinessID string    `gorm:"column:business_id"`
+	CreatedAt  time.Time `gorm:"column:created_at"`
+}
+
+func (BusinessMember) TableName() string {
+	return "business_members"
+}
+
+func NewBusinessRepo(db *gorm.DB) (*BusinessRepo, error) {
+	if db == nil {
+		return nil, errNilDB
+	}
+	return &BusinessRepo{db: db}, nil
+}
+
+func (r *BusinessRepo) ListMembers(businessID string, raw url.Values) (*pagination.PagingResponse[BusinessMember], error) {
+	if r == nil || r.db == nil {
+		return nil, errNilDB
+	}
+
+	params, err := pagination.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	base := r.db.Model(&BusinessMember{}).Where("business_id = ?", businessID)
+	query, err := pagination.Apply(base, params)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := params.Limit
+	if limit <= 0 {
+		limit = pagination.DefaultLimit
+	}
+
+	query = query.Limit(limit + 1)
+
+	var results []BusinessMember
+	if err := query.Find(&results).Error; err != nil {
+		return nil, err
+	}
+
+	page, err := pagination.BuildPage[BusinessMember](params, results, limit, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &page, nil
+}

--- a/examples/businessrepo/repo_test.go
+++ b/examples/businessrepo/repo_test.go
@@ -1,0 +1,143 @@
+package businessrepo
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+)
+
+func TestBuildPage_FirstPageWithoutCursor(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	members := []BusinessMember{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	page, err := pagination.BuildPage[BusinessMember](params, members, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if len(page.Data) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(page.Data))
+	}
+
+	if !page.Paging.HasMore {
+		t.Fatalf("expected hasMore to be true")
+	}
+
+	if page.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor to be generated")
+	}
+
+	if page.Paging.PrevCursor != "" {
+		t.Fatalf("expected prev cursor to be empty on first page")
+	}
+}
+
+func TestBuildPage_GeneratesPrevCursorForSubsequentPage(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	firstMembers := []BusinessMember{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	firstPage, err := pagination.BuildPage[BusinessMember](params, firstMembers, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage (first page) returned error: %v", err)
+	}
+
+	if firstPage.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor on first page")
+	}
+
+	secondRaw := url.Values{}
+	secondRaw.Set("cursor", firstPage.Paging.NextCursor)
+	secondRaw.Set("limit", "2")
+
+	secondParams, err := pagination.Parse(secondRaw)
+	if err != nil {
+		t.Fatalf("Parse (second page) returned error: %v", err)
+	}
+
+	secondMembers := []BusinessMember{{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}}
+
+	secondPage, err := pagination.BuildPage[BusinessMember](secondParams, secondMembers, secondParams.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage (second page) returned error: %v", err)
+	}
+
+	if secondPage.Paging.HasMore {
+		t.Fatalf("expected hasMore to be false on final page")
+	}
+
+	if secondPage.Paging.NextCursor != "" {
+		t.Fatalf("expected empty next cursor on final page")
+	}
+
+	if secondPage.Paging.PrevCursor == "" {
+		t.Fatalf("expected prev cursor to be generated on subsequent page")
+	}
+
+	payload, err := pagination.DecodeCursor(secondPage.Paging.PrevCursor)
+	if err != nil {
+		t.Fatalf("failed to decode prev cursor: %v", err)
+	}
+
+	if payload.Before["id"] != secondMembers[0].ID {
+		t.Fatalf("expected prev cursor id %q, got %q", secondMembers[0].ID, payload.Before["id"])
+	}
+}
+
+func TestBuildPage_NoResultsKeepsPrevCursor(t *testing.T) {
+	params := pagination.Params{
+		Limit: 2,
+		Cursor: &pagination.CursorPayload{
+			Sort: []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+		},
+		RawCursor: "dummy-cursor",
+		Sort:      []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+	}
+
+	page, err := pagination.BuildPage[BusinessMember](params, nil, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if page.Paging.PrevCursor != params.RawCursor {
+		t.Fatalf("expected prev cursor to reuse raw cursor when no results, got %q", page.Paging.PrevCursor)
+	}
+}
+
+func TestBuildPage_RequiresExtractorWhenNeeded(t *testing.T) {
+	params := pagination.Params{
+		Limit: 1,
+		Sort:  []pagination.SortExpression{{Field: "non_existent", Direction: pagination.DirectionAsc}},
+	}
+
+	members := []BusinessMember{{ID: "mem-1", CreatedAt: time.Now().UTC()}, {ID: "mem-2", CreatedAt: time.Now().UTC()}}
+
+	if _, err := pagination.BuildPage[BusinessMember](params, members, params.Limit, nil); err == nil {
+		t.Fatalf("expected error when automatic extraction cannot find field")
+	}
+}

--- a/uker/pagination/pagebuilder.go
+++ b/uker/pagination/pagebuilder.go
@@ -1,0 +1,291 @@
+package pagination
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// ErrNilCursorExtractor is returned when BuildPage requires cursor boundary values
+// but no extractor function was provided.
+var ErrNilCursorExtractor = errors.New("pagination: nil cursor extractor")
+
+// CursorExtractor defines the function signature used by BuildPage to obtain the
+// boundary values for the first and last records of a result set. The returned
+// map should contain the fields referenced in Params.Sort so subsequent cursors
+// can be generated.
+type CursorExtractor[T any] func(item T) (map[string]string, error)
+
+// BuildPage constructs a PagingResponse using the provided query parameters and
+// result slice. The function expects the slice to contain up to limit+1
+// elements, where the extra record is used to determine whether there is
+// another page available. Callers must provide an extractor that converts a
+// record into the cursor value map understood by BuildNextCursor/BuildPrevCursor.
+func BuildPage[T any](params Params, results []T, limit int, extract CursorExtractor[T]) (PagingResponse[T], error) {
+	if limit < 0 {
+		limit = 0
+	}
+
+	items := results
+	hasMore := false
+	if len(results) > limit {
+		hasMore = true
+		if limit < len(results) {
+			items = results[:limit]
+		}
+	}
+
+	needsExtractor := (hasMore && limit > 0) || (params.Cursor != nil && len(items) > 0)
+	var err error
+	if extract == nil && needsExtractor {
+		extract, err = newAutoCursorExtractor[T](params, items)
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+	}
+
+	var nextCursor string
+	if hasMore && limit > 0 {
+		if extract == nil {
+			return PagingResponse[T]{}, ErrNilCursorExtractor
+		}
+
+		cursorValues, err := extract(items[len(items)-1])
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+
+		nextCursor, err = BuildNextCursor(params, cursorValues)
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+	}
+
+	var prevCursor string
+	if params.Cursor != nil {
+		if len(items) == 0 {
+			prevCursor = params.RawCursor
+		} else {
+			if extract == nil {
+				return PagingResponse[T]{}, ErrNilCursorExtractor
+			}
+
+			cursorValues, err := extract(items[0])
+			if err != nil {
+				return PagingResponse[T]{}, err
+			}
+
+			prevCursor, err = BuildPrevCursor(params, cursorValues)
+			if err != nil {
+				return PagingResponse[T]{}, err
+			}
+		}
+	}
+
+	return NewPage(items, limit, hasMore, nextCursor, prevCursor), nil
+}
+
+func newAutoCursorExtractor[T any](params Params, items []T) (CursorExtractor[T], error) {
+	if len(params.Sort) == 0 {
+		return func(T) (map[string]string, error) {
+			return nil, nil
+		}, nil
+	}
+
+	structType, err := inferStructType[T](items)
+	if err != nil {
+		return nil, err
+	}
+
+	accessors, err := buildFieldAccessors(structType, params.Sort)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(item T) (map[string]string, error) {
+		value := reflect.ValueOf(item)
+		if !value.IsValid() {
+			return nil, errors.New("pagination: cannot extract cursor values from invalid item")
+		}
+
+		// Handle pointers to the underlying struct.
+		if value.Kind() == reflect.Pointer {
+			if value.IsNil() {
+				return nil, errors.New("pagination: cannot extract cursor values from nil pointer item")
+			}
+			value = value.Elem()
+		}
+
+		if value.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("pagination: automatic cursor extraction expects struct items, got %s", value.Kind())
+		}
+
+		cursor := make(map[string]string, len(accessors))
+		for _, accessor := range accessors {
+			field := value.Field(accessor.index)
+			encoded, err := formatCursorValue(field)
+			if err != nil {
+				return nil, fmt.Errorf("pagination: %s", err)
+			}
+			cursor[accessor.sortField] = encoded
+		}
+
+		return cursor, nil
+	}, nil
+}
+
+func inferStructType[T any](items []T) (reflect.Type, error) {
+	for _, item := range items {
+		value := reflect.ValueOf(item)
+		if !value.IsValid() {
+			continue
+		}
+		typ := value.Type()
+		if typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		if typ.Kind() == reflect.Struct {
+			return typ, nil
+		}
+	}
+
+	var zero T
+	typ := reflect.TypeOf(zero)
+	if typ == nil {
+		return nil, errors.New("pagination: cannot infer result type for automatic cursor extraction")
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("pagination: automatic cursor extraction requires struct results, got %s", typ.Kind())
+	}
+	return typ, nil
+}
+
+type fieldAccessor struct {
+	sortField string
+	index     int
+}
+
+func buildFieldAccessors(structType reflect.Type, sorts []SortExpression) ([]fieldAccessor, error) {
+	lookup := map[string]int{}
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		for _, alias := range fieldAliases(field) {
+			key := strings.ToLower(alias)
+			if _, exists := lookup[key]; !exists {
+				lookup[key] = i
+			}
+		}
+	}
+
+	accessors := make([]fieldAccessor, 0, len(sorts))
+	for _, sort := range sorts {
+		key := strings.ToLower(sort.Field)
+		index, ok := lookup[key]
+		if !ok {
+			return nil, fmt.Errorf("pagination: cannot find field %q in %s for automatic cursor extraction", sort.Field, structType.Name())
+		}
+		accessors = append(accessors, fieldAccessor{sortField: sort.Field, index: index})
+	}
+
+	return accessors, nil
+}
+
+func fieldAliases(field reflect.StructField) []string {
+	aliases := []string{field.Name, toSnake(field.Name)}
+
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		name := strings.Split(jsonTag, ",")[0]
+		if name != "" && name != "-" {
+			aliases = append(aliases, name)
+		}
+	}
+
+	if dbTag := field.Tag.Get("db"); dbTag != "" {
+		aliases = append(aliases, strings.Split(dbTag, ",")[0])
+	}
+
+	if gormTag := field.Tag.Get("gorm"); gormTag != "" {
+		for _, part := range strings.Split(gormTag, ";") {
+			part = strings.TrimSpace(part)
+			if strings.HasPrefix(part, "column:") {
+				aliases = append(aliases, strings.TrimPrefix(part, "column:"))
+			}
+		}
+	}
+
+	return aliases
+}
+
+func formatCursorValue(value reflect.Value) (string, error) {
+	for value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return "", nil
+		}
+		value = value.Elem()
+	}
+
+	if !value.IsValid() {
+		return "", nil
+	}
+
+	if value.Type() == reflect.TypeOf(time.Time{}) {
+		if !value.CanInterface() {
+			return "", errors.New("time field is not accessible")
+		}
+		t := value.Interface().(time.Time)
+		return t.UTC().Format(time.RFC3339), nil
+	}
+
+	if value.CanInterface() {
+		if stringer, ok := value.Interface().(fmt.Stringer); ok {
+			return stringer.String(), nil
+		}
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Bool:
+		if value.CanInterface() {
+			return fmt.Sprintf("%v", value.Interface()), nil
+		}
+	}
+
+	if value.CanInterface() {
+		return fmt.Sprintf("%v", value.Interface()), nil
+	}
+
+	return "", errors.New("unsupported field type for cursor encoding")
+}
+
+func toSnake(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(raw) + len(raw)/2)
+	for i, runeValue := range raw {
+		if unicode.IsUpper(runeValue) {
+			if i > 0 {
+				builder.WriteByte('_')
+			}
+			builder.WriteRune(unicode.ToLower(runeValue))
+		} else {
+			builder.WriteRune(runeValue)
+		}
+	}
+	return builder.String()
+}

--- a/uker/pagination/pagebuilder_test.go
+++ b/uker/pagination/pagebuilder_test.go
@@ -1,0 +1,148 @@
+package pagination_test
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+)
+
+type member struct {
+	ID        string    `gorm:"column:id"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+}
+
+func TestBuildPage_FirstPageWithoutCursor(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse params: %v", err)
+	}
+
+	members := []member{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	page, err := pagination.BuildPage[member](params, members, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if len(page.Data) != params.Limit {
+		t.Fatalf("expected %d items, got %d", params.Limit, len(page.Data))
+	}
+
+	if !page.Paging.HasMore {
+		t.Fatalf("expected hasMore to be true")
+	}
+
+	if page.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor to be generated")
+	}
+
+	if page.Paging.PrevCursor != "" {
+		t.Fatalf("expected prev cursor to be empty on first page")
+	}
+}
+
+func TestBuildPage_GeneratesPrevCursorForSubsequentPage(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse params: %v", err)
+	}
+
+	firstMembers := []member{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	firstPage, err := pagination.BuildPage[member](params, firstMembers, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage (first page) returned error: %v", err)
+	}
+
+	if firstPage.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor on first page")
+	}
+
+	secondRaw := url.Values{}
+	secondRaw.Set("cursor", firstPage.Paging.NextCursor)
+	secondRaw.Set("limit", "2")
+
+	secondParams, err := pagination.Parse(secondRaw)
+	if err != nil {
+		t.Fatalf("parse (second page) params: %v", err)
+	}
+
+	secondMembers := []member{{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}}
+
+	secondPage, err := pagination.BuildPage[member](secondParams, secondMembers, secondParams.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage (second page) returned error: %v", err)
+	}
+
+	if secondPage.Paging.HasMore {
+		t.Fatalf("expected hasMore to be false on final page")
+	}
+
+	if secondPage.Paging.NextCursor != "" {
+		t.Fatalf("expected empty next cursor on final page")
+	}
+
+	if secondPage.Paging.PrevCursor == "" {
+		t.Fatalf("expected prev cursor to be generated on subsequent page")
+	}
+
+	payload, err := pagination.DecodeCursor(secondPage.Paging.PrevCursor)
+	if err != nil {
+		t.Fatalf("decode prev cursor: %v", err)
+	}
+
+	if payload.Before["id"] != secondMembers[0].ID {
+		t.Fatalf("expected prev cursor id %q, got %q", secondMembers[0].ID, payload.Before["id"])
+	}
+}
+
+func TestBuildPage_NoResultsKeepsPrevCursor(t *testing.T) {
+	params := pagination.Params{
+		Limit: 2,
+		Cursor: &pagination.CursorPayload{
+			Sort: []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+		},
+		RawCursor: "dummy-cursor",
+		Sort:      []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+	}
+
+	page, err := pagination.BuildPage[member](params, nil, params.Limit, nil)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if page.Paging.PrevCursor != params.RawCursor {
+		t.Fatalf("expected prev cursor to reuse raw cursor when no results, got %q", page.Paging.PrevCursor)
+	}
+}
+
+func TestBuildPage_AutomaticExtractorMissingField(t *testing.T) {
+	params := pagination.Params{
+		Limit: 1,
+		Sort:  []pagination.SortExpression{{Field: "non_existent", Direction: pagination.DirectionAsc}},
+	}
+
+	members := []member{{ID: "mem-1", CreatedAt: time.Now().UTC()}, {ID: "mem-2", CreatedAt: time.Now().UTC()}}
+
+	if _, err := pagination.BuildPage[member](params, members, params.Limit, nil); err == nil {
+		t.Fatalf("expected error when automatic extraction cannot resolve sort field")
+	}
+}


### PR DESCRIPTION
## Summary
- add automatic cursor extraction in pagination.BuildPage so most repositories can pass nil extractors
- drop the bespoke cursorValuesFromMember helper and rely on the shared automation in the business repo example
- extend pagination and example tests to cover the automatic extractor and error handling paths

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da33f6dd408332ade8d32101b16a40