### PR TITLE
Secure pagination with signed cursors and hardened queries

### DIFF
--- a/examples/businessrepo/repo.go
+++ b/examples/businessrepo/repo.go
@@ -1,0 +1,75 @@
+package businessrepo
+
+import (
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+	"gorm.io/gorm"
+)
+
+var errNilDB = errors.New("businessrepo: nil db")
+
+type BusinessRepo struct {
+	db           *gorm.DB
+	cursorSecret []byte
+	cursorTTL    time.Duration
+}
+
+type BusinessMember struct {
+	ID         string    `gorm:"column:id;primaryKey"`
+	BusinessID string    `gorm:"column:business_id"`
+	CreatedAt  time.Time `gorm:"column:created_at"`
+}
+
+func (BusinessMember) TableName() string {
+	return "business_members"
+}
+
+func NewBusinessRepo(db *gorm.DB, secret []byte, ttl time.Duration) (*BusinessRepo, error) {
+	if db == nil {
+		return nil, errNilDB
+	}
+	if len(secret) == 0 {
+		return nil, errors.New("businessrepo: missing cursor secret")
+	}
+	if ttl < 0 {
+		ttl = 0
+	}
+	return &BusinessRepo{db: db, cursorSecret: append([]byte(nil), secret...), cursorTTL: ttl}, nil
+}
+
+func (r *BusinessRepo) ListMembers(businessID string, raw url.Values) (*pagination.PagingResponse[BusinessMember], error) {
+	if r == nil || r.db == nil {
+		return nil, errNilDB
+	}
+
+	params, err := pagination.ParseWithSecurity(raw, r.cursorSecret, r.cursorTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	base := r.db.Model(&BusinessMember{}).Where("business_id = ?", businessID)
+	query, err := pagination.Apply(base, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []BusinessMember
+	if err := query.Find(&results).Error; err != nil {
+		return nil, err
+	}
+
+	limit := params.Limit
+	if limit <= 0 {
+		limit = pagination.DefaultLimit
+	}
+
+	page, err := pagination.BuildPageSigned[BusinessMember](params, results, limit, nil, r.cursorSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &page, nil
+}

--- a/examples/businessrepo/repo_test.go
+++ b/examples/businessrepo/repo_test.go
@@ -1,0 +1,145 @@
+package businessrepo
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+)
+
+var testSecret = []byte("test-secret")
+
+func TestBuildPage_FirstPageWithoutCursor(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.ParseWithSecurity(raw, testSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	members := []BusinessMember{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	page, err := pagination.BuildPageSigned[BusinessMember](params, members, params.Limit, nil, testSecret)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if len(page.Data) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(page.Data))
+	}
+
+	if !page.Paging.HasMore {
+		t.Fatalf("expected hasMore to be true")
+	}
+
+	if page.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor to be generated")
+	}
+
+	if page.Paging.PrevCursor != "" {
+		t.Fatalf("expected prev cursor to be empty on first page")
+	}
+}
+
+func TestBuildPage_GeneratesPrevCursorForSubsequentPage(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.ParseWithSecurity(raw, testSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	firstMembers := []BusinessMember{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	firstPage, err := pagination.BuildPageSigned[BusinessMember](params, firstMembers, params.Limit, nil, testSecret)
+	if err != nil {
+		t.Fatalf("BuildPage (first page) returned error: %v", err)
+	}
+
+	if firstPage.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor on first page")
+	}
+
+	secondRaw := url.Values{}
+	secondRaw.Set("cursor", firstPage.Paging.NextCursor)
+	secondRaw.Set("limit", "2")
+
+	secondParams, err := pagination.ParseWithSecurity(secondRaw, testSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("Parse (second page) returned error: %v", err)
+	}
+
+	secondMembers := []BusinessMember{{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}}
+
+	secondPage, err := pagination.BuildPageSigned[BusinessMember](secondParams, secondMembers, secondParams.Limit, nil, testSecret)
+	if err != nil {
+		t.Fatalf("BuildPage (second page) returned error: %v", err)
+	}
+
+	if secondPage.Paging.HasMore {
+		t.Fatalf("expected hasMore to be false on final page")
+	}
+
+	if secondPage.Paging.NextCursor != "" {
+		t.Fatalf("expected empty next cursor on final page")
+	}
+
+	if secondPage.Paging.PrevCursor == "" {
+		t.Fatalf("expected prev cursor to be generated on subsequent page")
+	}
+
+	payload, err := pagination.DecodeCursorSigned(secondPage.Paging.PrevCursor, testSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("failed to decode prev cursor: %v", err)
+	}
+
+	if payload.Before["id"] != secondMembers[0].ID {
+		t.Fatalf("expected prev cursor id %q, got %q", secondMembers[0].ID, payload.Before["id"])
+	}
+}
+
+func TestBuildPage_NoResultsKeepsPrevCursor(t *testing.T) {
+	params := pagination.Params{
+		Limit: 2,
+		Cursor: &pagination.CursorPayload{
+			Sort: []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+		},
+		RawCursor: "dummy-cursor",
+		Sort:      []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+	}
+
+	page, err := pagination.BuildPageSigned[BusinessMember](params, nil, params.Limit, nil, testSecret)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if page.Paging.PrevCursor != params.RawCursor {
+		t.Fatalf("expected prev cursor to reuse raw cursor when no results, got %q", page.Paging.PrevCursor)
+	}
+}
+
+func TestBuildPage_RequiresExtractorWhenNeeded(t *testing.T) {
+	params := pagination.Params{
+		Limit: 1,
+		Sort:  []pagination.SortExpression{{Field: "non_existent", Direction: pagination.DirectionAsc}},
+	}
+
+	members := []BusinessMember{{ID: "mem-1", CreatedAt: time.Now().UTC()}, {ID: "mem-2", CreatedAt: time.Now().UTC()}}
+
+	if _, err := pagination.BuildPageSigned[BusinessMember](params, members, params.Limit, nil, testSecret); err == nil {
+		t.Fatalf("expected error when automatic extraction cannot find field")
+	}
+}

--- a/uker/pagination/cursor_signed.go
+++ b/uker/pagination/cursor_signed.go
@@ -1,0 +1,127 @@
+package pagination
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/unknowns24/uker/internal/base64url"
+)
+
+type cursorNoSig struct {
+	Version   int               `json:"v"`
+	Sort      []SortExpression  `json:"sort,omitempty"`
+	Filters   map[string]string `json:"filters,omitempty"`
+	After     map[string]string `json:"after,omitempty"`
+	Before    map[string]string `json:"before,omitempty"`
+	Timestamp int64             `json:"ts,omitempty"`
+}
+
+func signCursorPayload(payload cursorNoSig, secret []byte) (string, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, secret)
+	if _, err := mac.Write(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// EncodeCursorSigned serialises the cursor payload and appends an HMAC signature using the provided secret.
+func EncodeCursorSigned(payload CursorPayload, secret []byte) (string, error) {
+	if len(secret) == 0 {
+		return "", errors.New("pagination: missing cursor signing secret")
+	}
+	if payload.Version == 0 {
+		payload.Version = 1
+	}
+	if payload.Timestamp == 0 {
+		payload.Timestamp = time.Now().Unix()
+	}
+
+	core := cursorNoSig{
+		Version:   payload.Version,
+		Sort:      payload.Sort,
+		Filters:   payload.Filters,
+		After:     payload.After,
+		Before:    payload.Before,
+		Timestamp: payload.Timestamp,
+	}
+
+	signature, err := signCursorPayload(core, secret)
+	if err != nil {
+		return "", err
+	}
+	payload.Signature = signature
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	return base64url.Encode(string(raw)), nil
+}
+
+// DecodeCursorSigned verifies the cursor signature and TTL before returning the payload.
+func DecodeCursorSigned(encoded string, secret []byte, ttl time.Duration) (CursorPayload, error) {
+	if encoded == "" {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+	if len(secret) == 0 {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+
+	decoded, err := base64url.Decode(encoded)
+	if err != nil {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+
+	var payload CursorPayload
+	if err := json.Unmarshal([]byte(decoded), &payload); err != nil {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+
+	if payload.Version <= 0 || payload.Signature == "" {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+
+	core := cursorNoSig{
+		Version:   payload.Version,
+		Sort:      payload.Sort,
+		Filters:   payload.Filters,
+		After:     payload.After,
+		Before:    payload.Before,
+		Timestamp: payload.Timestamp,
+	}
+
+	expected, err := signCursorPayload(core, secret)
+	if err != nil {
+		return CursorPayload{}, err
+	}
+
+	providedSig, err := base64.RawURLEncoding.DecodeString(payload.Signature)
+	if err != nil {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+	expectedSig, err := base64.RawURLEncoding.DecodeString(expected)
+	if err != nil {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+	if !hmac.Equal(providedSig, expectedSig) {
+		return CursorPayload{}, ErrInvalidCursor
+	}
+
+	if ttl > 0 {
+		expiresAt := time.Unix(payload.Timestamp, 0).Add(ttl)
+		if time.Now().After(expiresAt) {
+			return CursorPayload{}, ErrCursorExpired
+		}
+	}
+
+	return payload, nil
+}

--- a/uker/pagination/ident.go
+++ b/uker/pagination/ident.go
@@ -1,0 +1,45 @@
+package pagination
+
+import (
+	"errors"
+	"regexp"
+)
+
+var identRe = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// AllowedColumns enables opt-in whitelisting of identifiers. When populated, only
+// identifiers present in the map will be accepted by safeIdent. Leaving it nil or
+// empty disables the whitelist and relies solely on the regular expression check.
+var AllowedColumns map[string]struct{}
+
+// safeIdent validates that the provided identifier is free of SQL meta characters and
+// optionally belongs to the AllowedColumns whitelist. It returns ErrInvalidIdentifier
+// when the value cannot be used safely in a query.
+func safeIdent(value string) (string, error) {
+	if value == "" {
+		return "", ErrInvalidIdentifier
+	}
+	if !identRe.MatchString(value) {
+		return "", ErrInvalidIdentifier
+	}
+
+	if len(AllowedColumns) > 0 {
+		if _, ok := AllowedColumns[value]; !ok {
+			return "", ErrInvalidIdentifier
+		}
+	}
+
+	return value, nil
+}
+
+// requireIdent acts like safeIdent but converts the sentinel error into the provided one.
+func requireIdent(value string, errToWrap error) (string, error) {
+	identifier, err := safeIdent(value)
+	if err != nil {
+		if errors.Is(err, ErrInvalidIdentifier) {
+			return "", errToWrap
+		}
+		return "", err
+	}
+	return identifier, nil
+}

--- a/uker/pagination/pagebuilder.go
+++ b/uker/pagination/pagebuilder.go
@@ -1,0 +1,328 @@
+package pagination
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// ErrNilCursorExtractor is returned when BuildPage requires cursor boundary values
+// but no extractor function was provided.
+var ErrNilCursorExtractor = errors.New("pagination: nil cursor extractor")
+
+type cursorEncodeFunc func(CursorPayload) (string, error)
+
+// CursorExtractor defines the function signature used by BuildPage to obtain the
+// boundary values for the first and last records of a result set. The returned
+// map should contain the fields referenced in Params.Sort so subsequent cursors
+// can be generated.
+type CursorExtractor[T any] func(item T) (map[string]string, error)
+
+// BuildPage constructs a PagingResponse using the provided query parameters and
+// result slice. The function expects the slice to contain up to limit+1
+// elements, where the extra record is used to determine whether there is
+// another page available. Callers must provide an extractor that converts a
+// record into the cursor value map understood by BuildNextCursor/BuildPrevCursor.
+func BuildPage[T any](params Params, results []T, limit int, extract CursorExtractor[T]) (PagingResponse[T], error) {
+	encode := func(payload CursorPayload) (string, error) {
+		return EncodeCursor(payload)
+	}
+	return buildPageWithEncoders(params, results, limit, extract, encode, encode)
+}
+
+// BuildPageSigned behaves like BuildPage but signs generated cursors with the provided secret.
+func BuildPageSigned[T any](params Params, results []T, limit int, extract CursorExtractor[T], secret []byte) (PagingResponse[T], error) {
+	if len(secret) == 0 {
+		return PagingResponse[T]{}, errors.New("pagination: missing cursor signing secret")
+	}
+
+	encode := func(payload CursorPayload) (string, error) {
+		return EncodeCursorSigned(payload, secret)
+	}
+	return buildPageWithEncoders(params, results, limit, extract, encode, encode)
+}
+
+func buildPageWithEncoders[T any](params Params, results []T, limit int, extract CursorExtractor[T], encodeNext, encodePrev cursorEncodeFunc) (PagingResponse[T], error) {
+	if limit < 0 {
+		limit = 0
+	}
+
+	items := results
+	hasMore := false
+	if len(results) > limit {
+		hasMore = true
+		if limit < len(results) {
+			items = results[:limit]
+		}
+	}
+
+	needsExtractor := (hasMore && limit > 0) || (params.Cursor != nil && len(items) > 0)
+	var err error
+	if extract == nil && needsExtractor {
+		extract, err = newAutoCursorExtractor[T](params, items)
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+	}
+
+	if encodeNext == nil || encodePrev == nil {
+		return PagingResponse[T]{}, errors.New("pagination: nil cursor encoder")
+	}
+
+	var nextCursor string
+	if hasMore && limit > 0 {
+		if extract == nil {
+			return PagingResponse[T]{}, ErrNilCursorExtractor
+		}
+
+		cursorValues, err := extract(items[len(items)-1])
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+
+		payload, err := buildNextCursorPayload(params, cursorValues)
+		if err != nil {
+			return PagingResponse[T]{}, err
+		}
+		if payload != nil {
+			nextCursor, err = encodeNext(*payload)
+			if err != nil {
+				return PagingResponse[T]{}, err
+			}
+		}
+	}
+
+	var prevCursor string
+	if params.Cursor != nil {
+		if len(items) == 0 {
+			prevCursor = params.RawCursor
+		} else {
+			if extract == nil {
+				return PagingResponse[T]{}, ErrNilCursorExtractor
+			}
+
+			cursorValues, err := extract(items[0])
+			if err != nil {
+				return PagingResponse[T]{}, err
+			}
+
+			payload, err := buildPrevCursorPayload(params, cursorValues)
+			if err != nil {
+				return PagingResponse[T]{}, err
+			}
+			if payload != nil {
+				prevCursor, err = encodePrev(*payload)
+				if err != nil {
+					return PagingResponse[T]{}, err
+				}
+			}
+		}
+	}
+
+	return NewPage(items, limit, hasMore, nextCursor, prevCursor), nil
+}
+
+func newAutoCursorExtractor[T any](params Params, items []T) (CursorExtractor[T], error) {
+	if len(params.Sort) == 0 {
+		return func(T) (map[string]string, error) {
+			return nil, nil
+		}, nil
+	}
+
+	structType, err := inferStructType[T](items)
+	if err != nil {
+		return nil, err
+	}
+
+	accessors, err := buildFieldAccessors(structType, params.Sort)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(item T) (map[string]string, error) {
+		value := reflect.ValueOf(item)
+		if !value.IsValid() {
+			return nil, errors.New("pagination: cannot extract cursor values from invalid item")
+		}
+
+		// Handle pointers to the underlying struct.
+		if value.Kind() == reflect.Pointer {
+			if value.IsNil() {
+				return nil, errors.New("pagination: cannot extract cursor values from nil pointer item")
+			}
+			value = value.Elem()
+		}
+
+		if value.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("pagination: automatic cursor extraction expects struct items, got %s", value.Kind())
+		}
+
+		cursor := make(map[string]string, len(accessors))
+		for _, accessor := range accessors {
+			field := value.Field(accessor.index)
+			encoded, err := formatCursorValue(field)
+			if err != nil {
+				return nil, fmt.Errorf("pagination: %s", err)
+			}
+			cursor[accessor.sortField] = encoded
+		}
+
+		return cursor, nil
+	}, nil
+}
+
+func inferStructType[T any](items []T) (reflect.Type, error) {
+	for _, item := range items {
+		value := reflect.ValueOf(item)
+		if !value.IsValid() {
+			continue
+		}
+		typ := value.Type()
+		if typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		if typ.Kind() == reflect.Struct {
+			return typ, nil
+		}
+	}
+
+	var zero T
+	typ := reflect.TypeOf(zero)
+	if typ == nil {
+		return nil, errors.New("pagination: cannot infer result type for automatic cursor extraction")
+	}
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("pagination: automatic cursor extraction requires struct results, got %s", typ.Kind())
+	}
+	return typ, nil
+}
+
+type fieldAccessor struct {
+	sortField string
+	index     int
+}
+
+func buildFieldAccessors(structType reflect.Type, sorts []SortExpression) ([]fieldAccessor, error) {
+	lookup := map[string]int{}
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		for _, alias := range fieldAliases(field) {
+			key := strings.ToLower(alias)
+			if _, exists := lookup[key]; !exists {
+				lookup[key] = i
+			}
+		}
+	}
+
+	accessors := make([]fieldAccessor, 0, len(sorts))
+	for _, sort := range sorts {
+		key := strings.ToLower(sort.Field)
+		index, ok := lookup[key]
+		if !ok {
+			return nil, fmt.Errorf("pagination: cannot find field %q in %s for automatic cursor extraction", sort.Field, structType.Name())
+		}
+		accessors = append(accessors, fieldAccessor{sortField: sort.Field, index: index})
+	}
+
+	return accessors, nil
+}
+
+func fieldAliases(field reflect.StructField) []string {
+	aliases := []string{field.Name, toSnake(field.Name)}
+
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		name := strings.Split(jsonTag, ",")[0]
+		if name != "" && name != "-" {
+			aliases = append(aliases, name)
+		}
+	}
+
+	if dbTag := field.Tag.Get("db"); dbTag != "" {
+		aliases = append(aliases, strings.Split(dbTag, ",")[0])
+	}
+
+	if gormTag := field.Tag.Get("gorm"); gormTag != "" {
+		for _, part := range strings.Split(gormTag, ";") {
+			part = strings.TrimSpace(part)
+			if strings.HasPrefix(part, "column:") {
+				aliases = append(aliases, strings.TrimPrefix(part, "column:"))
+			}
+		}
+	}
+
+	return aliases
+}
+
+func formatCursorValue(value reflect.Value) (string, error) {
+	for value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return "", nil
+		}
+		value = value.Elem()
+	}
+
+	if !value.IsValid() {
+		return "", nil
+	}
+
+	if value.Type() == reflect.TypeOf(time.Time{}) {
+		if !value.CanInterface() {
+			return "", errors.New("time field is not accessible")
+		}
+		t := value.Interface().(time.Time)
+		return t.UTC().Format(time.RFC3339), nil
+	}
+
+	if value.CanInterface() {
+		if stringer, ok := value.Interface().(fmt.Stringer); ok {
+			return stringer.String(), nil
+		}
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Bool:
+		if value.CanInterface() {
+			return fmt.Sprintf("%v", value.Interface()), nil
+		}
+	}
+
+	if value.CanInterface() {
+		return fmt.Sprintf("%v", value.Interface()), nil
+	}
+
+	return "", errors.New("unsupported field type for cursor encoding")
+}
+
+func toSnake(raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(raw) + len(raw)/2)
+	for i, runeValue := range raw {
+		if unicode.IsUpper(runeValue) {
+			if i > 0 {
+				builder.WriteByte('_')
+			}
+			builder.WriteRune(unicode.ToLower(runeValue))
+		} else {
+			builder.WriteRune(runeValue)
+		}
+	}
+	return builder.String()
+}

--- a/uker/pagination/pagebuilder_test.go
+++ b/uker/pagination/pagebuilder_test.go
@@ -1,0 +1,150 @@
+package pagination_test
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/unknowns24/uker/uker/pagination"
+)
+
+var pageSecret = []byte("pagebuilder-secret")
+
+type member struct {
+	ID        string    `gorm:"column:id"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+}
+
+func TestBuildPage_FirstPageWithoutCursor(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.ParseWithSecurity(raw, pageSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("parse params: %v", err)
+	}
+
+	members := []member{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	page, err := pagination.BuildPageSigned[member](params, members, params.Limit, nil, pageSecret)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if len(page.Data) != params.Limit {
+		t.Fatalf("expected %d items, got %d", params.Limit, len(page.Data))
+	}
+
+	if !page.Paging.HasMore {
+		t.Fatalf("expected hasMore to be true")
+	}
+
+	if page.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor to be generated")
+	}
+
+	if page.Paging.PrevCursor != "" {
+		t.Fatalf("expected prev cursor to be empty on first page")
+	}
+}
+
+func TestBuildPage_GeneratesPrevCursorForSubsequentPage(t *testing.T) {
+	raw := url.Values{}
+	raw.Set("limit", "2")
+	raw.Set("sort", "created_at:asc")
+
+	params, err := pagination.ParseWithSecurity(raw, pageSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("parse params: %v", err)
+	}
+
+	firstMembers := []member{
+		{ID: "mem-1", CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+		{ID: "mem-2", CreatedAt: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC)},
+		{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	firstPage, err := pagination.BuildPageSigned[member](params, firstMembers, params.Limit, nil, pageSecret)
+	if err != nil {
+		t.Fatalf("BuildPage (first page) returned error: %v", err)
+	}
+
+	if firstPage.Paging.NextCursor == "" {
+		t.Fatalf("expected next cursor on first page")
+	}
+
+	secondRaw := url.Values{}
+	secondRaw.Set("cursor", firstPage.Paging.NextCursor)
+	secondRaw.Set("limit", "2")
+
+	secondParams, err := pagination.ParseWithSecurity(secondRaw, pageSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("parse (second page) params: %v", err)
+	}
+
+	secondMembers := []member{{ID: "mem-3", CreatedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}}
+
+	secondPage, err := pagination.BuildPageSigned[member](secondParams, secondMembers, secondParams.Limit, nil, pageSecret)
+	if err != nil {
+		t.Fatalf("BuildPage (second page) returned error: %v", err)
+	}
+
+	if secondPage.Paging.HasMore {
+		t.Fatalf("expected hasMore to be false on final page")
+	}
+
+	if secondPage.Paging.NextCursor != "" {
+		t.Fatalf("expected empty next cursor on final page")
+	}
+
+	if secondPage.Paging.PrevCursor == "" {
+		t.Fatalf("expected prev cursor to be generated on subsequent page")
+	}
+
+	payload, err := pagination.DecodeCursorSigned(secondPage.Paging.PrevCursor, pageSecret, time.Hour)
+	if err != nil {
+		t.Fatalf("decode prev cursor: %v", err)
+	}
+
+	if payload.Before["id"] != secondMembers[0].ID {
+		t.Fatalf("expected prev cursor id %q, got %q", secondMembers[0].ID, payload.Before["id"])
+	}
+}
+
+func TestBuildPage_NoResultsKeepsPrevCursor(t *testing.T) {
+	params := pagination.Params{
+		Limit: 2,
+		Cursor: &pagination.CursorPayload{
+			Sort: []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+		},
+		RawCursor: "dummy-cursor",
+		Sort:      []pagination.SortExpression{{Field: "id", Direction: pagination.DirectionDesc}},
+	}
+
+	page, err := pagination.BuildPageSigned[member](params, nil, params.Limit, nil, pageSecret)
+	if err != nil {
+		t.Fatalf("BuildPage returned error: %v", err)
+	}
+
+	if page.Paging.PrevCursor != params.RawCursor {
+		t.Fatalf("expected prev cursor to reuse raw cursor when no results, got %q", page.Paging.PrevCursor)
+	}
+}
+
+func TestBuildPage_AutomaticExtractorMissingField(t *testing.T) {
+	params := pagination.Params{
+		Limit: 1,
+		Sort:  []pagination.SortExpression{{Field: "non_existent", Direction: pagination.DirectionAsc}},
+	}
+
+	members := []member{{ID: "mem-1", CreatedAt: time.Now().UTC()}, {ID: "mem-2", CreatedAt: time.Now().UTC()}}
+
+	if _, err := pagination.BuildPageSigned[member](params, members, params.Limit, nil, pageSecret); err == nil {
+		t.Fatalf("expected error when automatic extraction cannot resolve sort field")
+	}
+}


### PR DESCRIPTION
## Summary
- add signed cursor encoding/decoding with TTL checks and reuse it from BuildNext/PrevCursor and the new BuildPageSigned helper
- harden Parse/Apply by validating identifiers, blocking filter overrides when a cursor is present, and fetching limit+1 rows with tuple keyset predicates
- update the business repo example, documentation, and tests to exercise the secure cursor flow end to end

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da33f6dd408332ade8d32101b16a40