### PR TITLE
feat: add min/max tag validation during body parsing

### DIFF
--- a/uker/httpx/httpx_test.go
+++ b/uker/httpx/httpx_test.go
@@ -149,6 +149,40 @@ func TestBodyParserMissingRequired(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 }
 
+type validationTaggedStruct struct {
+	Name string `json:"name" uker:"required,min=3"`
+	Age  int    `json:"age" uker:"required,min=18,max=65"`
+}
+
+func TestBodyParserTagValidation(t *testing.T) {
+	body, err := json.Marshal(validationTaggedStruct{Name: "Al", Age: 20})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	var data validationTaggedStruct
+	if err := httpx.BodyParser(req, &data); err == nil {
+		t.Fatalf("expected validation error for min length")
+	}
+}
+
+func TestBodyParserTagValidationIntRange(t *testing.T) {
+	body, err := json.Marshal(validationTaggedStruct{Name: "Alice", Age: 70})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	var data validationTaggedStruct
+	if err := httpx.BodyParser(req, &data); err == nil {
+		t.Fatalf("expected validation error for int max")
+	}
+}
 func TestFinalOutput(t *testing.T) {
 	rec := httptest.NewRecorder()
 	httpx.FinalOutput(rec, http.StatusOK, map[string]string{"key1": "value1"})

--- a/uker/httpx/request.go
+++ b/uker/httpx/request.go
@@ -72,7 +72,7 @@ func BodyParser(r *http.Request, target any, opts ...ParserOption) error {
 		dataFields = payload
 	}
 
-	return validate.RequiredFields(target, dataFields)
+	return validate.ValidateFields(target, dataFields)
 }
 
 // MultiPartFormParser decodes the provided values and returns the received files.
@@ -94,7 +94,7 @@ func MultiPartFormParser(r *http.Request, values map[string]any, files []string,
 			return nil, err
 		}
 
-		if err := validate.RequiredFields(target, dataFields); err != nil {
+		if err := validate.ValidateFields(target, dataFields); err != nil {
 			return nil, fmt.Errorf("missing required parameters in valueInterface: %s", err.Error())
 		}
 	}

--- a/uker/validate/validate.go
+++ b/uker/validate/validate.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
 const (
 	tagName          = "uker"
 	tagRequiredValue = "required"
+	tagMinValue      = "min"
+	tagMaxValue      = "max"
 )
 
 // NotEmpty validates that the provided string is not empty.
@@ -28,8 +31,15 @@ func MinLength(value string, length int) error {
 	return nil
 }
 
-// RequiredFields checks that struct fields tagged as required are present in the decoded body.
-func RequiredFields(target any, body map[string]any) error {
+// ValidateFields checks that tagged struct fields are valid in the decoded body.
+//
+// Supported tags:
+// - required
+// - min=<number>
+// - max=<number>
+//
+// The min/max tags apply to string lengths and numeric values.
+func ValidateFields(target any, body map[string]any) error {
 	value := reflect.ValueOf(target)
 	if value.Kind() != reflect.Ptr || value.IsNil() {
 		return errors.New("target must be a non-nil pointer")
@@ -42,7 +52,8 @@ func RequiredFields(target any, body map[string]any) error {
 
 	for i := 0; i < elem.NumField(); i++ {
 		field := elem.Type().Field(i)
-		if !strings.Contains(field.Tag.Get(tagName), tagRequiredValue) {
+		rules := parseRules(field.Tag.Get(tagName))
+		if len(rules) == 0 {
 			continue
 		}
 
@@ -55,13 +66,110 @@ func RequiredFields(target any, body map[string]any) error {
 		}
 
 		rawValue, ok := body[jsonKey]
-		if !ok || rawValue == nil {
+		_, required := rules[tagRequiredValue]
+		if required && (!ok || rawValue == nil) {
 			return fmt.Errorf("missing required parameter: %s", field.Name)
+		}
+		if !ok || rawValue == nil {
+			continue
 		}
 
 		fieldValue := elem.Field(i)
-		if fieldValue.Kind() == reflect.String && fieldValue.IsZero() {
+		if required && fieldValue.Kind() == reflect.String && fieldValue.IsZero() {
 			return fmt.Errorf("missing required parameter: %s", field.Name)
+		}
+
+		if min, ok := rules[tagMinValue]; ok {
+			if err := validateMin(field.Name, fieldValue, min); err != nil {
+				return err
+			}
+		}
+
+		if max, ok := rules[tagMaxValue]; ok {
+			if err := validateMax(field.Name, fieldValue, max); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// RequiredFields checks that struct fields tagged as required are present in the decoded body.
+func RequiredFields(target any, body map[string]any) error {
+	return ValidateFields(target, body)
+}
+
+func parseRules(tag string) map[string]string {
+	rules := map[string]string{}
+	for _, rule := range strings.Split(tag, ",") {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
+		}
+
+		if !strings.Contains(rule, "=") {
+			rules[rule] = ""
+			continue
+		}
+
+		parts := strings.SplitN(rule, "=", 2)
+		rules[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+
+	return rules
+}
+
+func validateMin(name string, value reflect.Value, rawMin string) error {
+	min, err := strconv.ParseFloat(rawMin, 64)
+	if err != nil {
+		return fmt.Errorf("invalid min value for field %s", name)
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		if float64(len(value.String())) < min {
+			return fmt.Errorf("field %s must be at least %.0f characters", name, min)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if float64(value.Int()) < min {
+			return fmt.Errorf("field %s must be >= %.0f", name, min)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if float64(value.Uint()) < min {
+			return fmt.Errorf("field %s must be >= %.0f", name, min)
+		}
+	case reflect.Float32, reflect.Float64:
+		if value.Float() < min {
+			return fmt.Errorf("field %s must be >= %v", name, min)
+		}
+	}
+
+	return nil
+}
+
+func validateMax(name string, value reflect.Value, rawMax string) error {
+	max, err := strconv.ParseFloat(rawMax, 64)
+	if err != nil {
+		return fmt.Errorf("invalid max value for field %s", name)
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		if float64(len(value.String())) > max {
+			return fmt.Errorf("field %s must be at most %.0f characters", name, max)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if float64(value.Int()) > max {
+			return fmt.Errorf("field %s must be <= %.0f", name, max)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if float64(value.Uint()) > max {
+			return fmt.Errorf("field %s must be <= %.0f", name, max)
+		}
+	case reflect.Float32, reflect.Float64:
+		if value.Float() > max {
+			return fmt.Errorf("field %s must be <= %v", name, max)
 		}
 	}
 

--- a/uker/validate/validate_test.go
+++ b/uker/validate/validate_test.go
@@ -22,31 +22,45 @@ func TestMinLength(t *testing.T) {
 	}
 }
 
-func TestRequiredFields(t *testing.T) {
+func TestValidateFields(t *testing.T) {
 	type payload struct {
-		Name string `json:"name" uker:"required"`
-		Age  int    `json:"age" uker:"required"`
+		Name string `json:"name" uker:"required,min=3,max=5"`
+		Age  int    `json:"age" uker:"required,min=18,max=65"`
 		Note string
 	}
 
 	valid := &payload{Name: "Alice", Age: 30}
 	body := map[string]any{"name": "Alice", "age": 30}
 
-	if err := RequiredFields(valid, body); err != nil {
+	if err := ValidateFields(valid, body); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	missing := &payload{Name: "Alice"}
 	bodyMissing := map[string]any{"name": "Alice"}
-
-	if err := RequiredFields(missing, bodyMissing); err == nil {
+	if err := ValidateFields(missing, bodyMissing); err == nil {
 		t.Fatalf("expected error for missing required field")
 	}
 
-	empty := &payload{Age: 25}
-	bodyEmpty := map[string]any{"name": "", "age": 25}
+	shortName := &payload{Name: "Al", Age: 25}
+	bodyShortName := map[string]any{"name": "Al", "age": 25}
+	if err := ValidateFields(shortName, bodyShortName); err == nil {
+		t.Fatalf("expected error for min string length")
+	}
 
-	if err := RequiredFields(empty, bodyEmpty); err == nil {
-		t.Fatalf("expected error for empty required field")
+	ageTooHigh := &payload{Name: "Alice", Age: 70}
+	bodyAgeTooHigh := map[string]any{"name": "Alice", "age": 70}
+	if err := ValidateFields(ageTooHigh, bodyAgeTooHigh); err == nil {
+		t.Fatalf("expected error for max int value")
+	}
+}
+
+func TestRequiredFieldsCompatibility(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" uker:"required"`
+	}
+
+	if err := RequiredFields(&payload{Name: "ok"}, map[string]any{"name": "ok"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Enforce richer validation rules at decode time so payloads are validated on `BodyParser` like `required` is today.
- Support common constraints such as minimum/maximum lengths for strings and numeric ranges for integers/floats via `uker` tags.

### Description
- Added a new entrypoint `ValidateFields` that parses `uker` tags and supports `required`, `min=<number>`, and `max=<number>` rules applied to strings and numeric kinds. 
- Implemented `parseRules`, `validateMin`, and `validateMax` helpers and kept backwards compatibility by making `RequiredFields` delegate to `ValidateFields`.
- Updated `httpx.BodyParser` and `httpx.MultiPartFormParser` to call `validate.ValidateFields` so constraints are enforced during body parsing.
- Added/updated tests in `uker/validate/validate_test.go` and `uker/httpx/httpx_test.go` to cover `min`/`max` validations for strings and ints and formatted code with `gofmt`.

### Testing
- Ran `go test ./...` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af5eeb3fe48332bf416ed781f57487)